### PR TITLE
make logout async

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -73,12 +73,7 @@
           <v-btn
             icon
             class="l-header_logout"
-            @click="
-              () => {
-                logout();
-                useRouter().push('/');
-              }
-            "
+            @click="handleLogout"
           >
             <v-icon>mdi-exit-to-app</v-icon>
           </v-btn>
@@ -142,6 +137,11 @@ const { authUser, isLoggedIn, logout } = useAuth();
 
 const drawer = ref(false);
 const clipped = ref(false);
+
+const handleLogout = async () => {
+  await logout();
+  useRouter().push("/");
+};
 const subtitle = computed(() => {
   if (authUser.value.member_id) {
     return "Hi, " + authUser.value.name1;


### PR DESCRIPTION
@yabe-diverta san

Fixes #57 
Evidence : https://diverta.gyazo.com/8a2ff065273f3f8379a0c2bf9ec0261b

Reason : the router did not wait for logout to complete its execution before moving to index page which led to user token still being active
Fix : await logout