### PR TITLE
Add lightweight 404 error page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Core Commands
+- `npm run dev` - Start development server
+- `npm run build` - Build for production
+- `npm run generate` - Generate static site
+- `npm run preview` - Preview production build locally
+- `npm install` - Install dependencies
+- `npm run postinstall` - Prepare Nuxt (runs automatically after install)
+
+### Code Quality
+- **Linting**: ESLint runs automatically via lint-staged on commit
+- **Formatting**: Prettier runs automatically via lint-staged on commit
+- **Pre-commit hooks**: Husky is configured with lint-staged to format and lint on commit
+
+## Project Architecture
+
+### Framework & Technology Stack
+- **Nuxt 3**: Vue.js framework with SSR/SSG capabilities
+- **Vue 3**: Frontend framework with Composition API
+- **TypeScript**: Type checking (nuxt.config.ts, formkit.config.ts)
+- **Vuetify 3**: Material Design component library
+- **FormKit**: Form handling with auto-import enabled
+- **i18n**: Internationalization (English/Japanese) with prefix strategy
+- **SASS/SCSS**: Styling with organized structure
+
+### API Integration
+- **Kuroco CMS**: Backend integration via `dev-nuxt-auth.a.kuroco.app` 
+- **Authentication**: Custom auth composable with login/logout/profile management
+- **API Domain**: Dynamic sitekey-based API endpoint switching
+
+### Key Architecture Patterns
+
+#### Authentication System
+- **useAuth composable** (`composables/useAuth.js`): Central auth management
+  - User state management via `useState('user')`
+  - Profile restoration on app load
+  - Dynamic API domain switching based on sitekey
+  - Route protection for authenticated areas
+
+#### Component Structure
+- **Layouts**: `default.vue` and `preview.vue` for different page types
+- **Components**: Organized by feature (topics/, reusable components)
+- **Pages**: File-based routing with dynamic routes (`[slug].vue`)
+
+#### Styling Architecture
+- **Modular SCSS**: Organized in assets/ with foundation, layout, object, and partials
+- **Design System**: Vuetify components with custom SCSS overrides
+- **Variables**: Centralized in `assets/variables.scss` and `assets/partials/_var.scss`
+
+#### Internationalization
+- **Strategy**: `prefix_except_default` (English default, `/ja` prefix for Japanese)
+- **Locales**: JSON files in `locales/` directory
+- **HTML support**: `strictMessage: false` allows HTML in translation strings
+
+### Important Files
+- `nuxt.config.ts` - Main configuration with modules and runtime config
+- `composables/useAuth.js` - Authentication logic and user state
+- `public/kuroco_front.json` - Frontend routing configuration for Kuroco
+- `eslint.config.mjs` - ESLint configuration with custom rules
+- `formkit.config.ts` - Form handling configuration
+
+### Development Notes
+- **Auto-imports**: FormKit and Vuetify components are auto-imported
+- **Development server**: Uses file watching with polling enabled
+- **Error handling**: Custom 404 page configured in kuroco_front.json
+- **State management**: Uses Nuxt's built-in `useState` for global state

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>404 - Page Not Found</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            margin: 0;
+            padding: 40px;
+            background: #f5f5f5;
+            color: #333;
+            text-align: center;
+        }
+        .container {
+            max-width: 400px;
+            margin: 100px auto;
+            background: white;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 {
+            margin: 0 0 20px 0;
+            font-size: 48px;
+            color: #666;
+        }
+        p {
+            margin: 0 0 20px 0;
+            line-height: 1.5;
+        }
+        a {
+            color: #1976d2;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>404</h1>
+        <p>お探しのページは見つかりませんでした。</p>
+        <p><a href="/">ホームに戻る</a></p>
+    </div>
+</body>
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -42,8 +42,8 @@
 <body>
     <div class="container">
         <h1>404</h1>
-        <p>お探しのページは見つかりませんでした。</p>
-        <p><a href="/">ホームに戻る</a></p>
+        <p>The page you are looking for could not be found.</p>
+        <p><a href="/">Go back to home</a></p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Create minimal HTML 404 error page to significantly reduce response size
- Add CLAUDE.md documentation for future development guidance

## Changes
- **public/404.html**: Lightweight 404 error page with inline CSS, no external dependencies
- **CLAUDE.md**: Comprehensive documentation covering project architecture, development commands, and key patterns

## Benefits
- Dramatically reduced 404 error response size (from full Nuxt app to minimal HTML)
- Better documentation for development workflow and project understanding
- Improved user experience with faster loading 404 pages

## Test plan
- [ ] Verify 404.html loads correctly when accessing non-existent pages
- [ ] Confirm reduced response size compared to previous 404 handling
- [ ] Test home page link functionality in 404 page

🤖 Generated with [Claude Code](https://claude.ai/code)